### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/philipcristiano/nostress/compare/v0.1.1...v0.1.2) - 2023-12-11
+
+### Other
+- *(deps)* bump agenthunt/conventional-commit-checker-action
+- *(deps)* bump the minor-dependencies group with 1 update
+- *(deps)* bump the patch-dependencies group with 1 update
+
 ## [0.1.1](https://github.com/philipcristiano/nostress/compare/v0.1.0...v0.1.1) - 2023-12-05
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1226,7 +1226,7 @@ dependencies = [
 
 [[package]]
 name = "nostress"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "axum 0.7.2",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nostress"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Nostr to RSS"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `nostress`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.2](https://github.com/philipcristiano/nostress/compare/v0.1.1...v0.1.2) - 2023-12-11

### Other
- *(deps)* bump agenthunt/conventional-commit-checker-action
- *(deps)* bump the minor-dependencies group with 1 update
- *(deps)* bump the patch-dependencies group with 1 update
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).