### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/philipcristiano/nostress/compare/v0.1.2...v0.1.3) - 2024-01-22
+
+### Other
+- Update nostrsdk usage for compat
+- *(deps)* bump the minor-dependencies group with 1 update
+- *(deps)* bump the patch-dependencies group with 1 update
+- Use explicit Action token
+- *(deps)* bump the patch-dependencies group with 5 updates
+- *(deps)* bump the patch-dependencies group with 2 updates
+- *(deps)* bump the patch-dependencies group with 2 updates
+- *(deps)* bump rust from 1.74-bookworm to 1.75-bookworm
+
 ## [0.1.2](https://github.com/philipcristiano/nostress/compare/v0.1.1...v0.1.2) - 2023-12-11
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1245,7 +1245,7 @@ dependencies = [
 
 [[package]]
 name = "nostress"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "axum 0.7.4",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nostress"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Nostr to RSS"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `nostress`: 0.1.2 -> 0.1.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/philipcristiano/nostress/compare/v0.1.2...v0.1.3) - 2024-01-22

### Other
- Update nostrsdk usage for compat
- *(deps)* bump the minor-dependencies group with 1 update
- *(deps)* bump the patch-dependencies group with 1 update
- Use explicit Action token
- *(deps)* bump the patch-dependencies group with 5 updates
- *(deps)* bump the patch-dependencies group with 2 updates
- *(deps)* bump the patch-dependencies group with 2 updates
- *(deps)* bump rust from 1.74-bookworm to 1.75-bookworm
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).